### PR TITLE
In mozilla.cfg start on the 2. line or later

### DIFF
--- a/install-all-firefox.sh
+++ b/install-all-firefox.sh
@@ -1137,6 +1137,8 @@ EOL
 # make config
 config_file="${config_dir}mozilla.cfg"
 cat > "${config_file}" <<EOL
+// always start on 2. line (or later I assume), a feature not a bug
+// see https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig
 lockPref("browser.shell.checkDefaultBrowser", false);
 lockPref("browser.startup.homepage_override.mstone", "ignore");
 lockPref("app.update.enabled", false);


### PR DESCRIPTION
I got the problem that the firefoxes asked to be the default browser although it was set not to ask in mozilla.cfg. Turns out to be a feature or a bug :), see https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig.

Adding a comment at the start of the file solves it.